### PR TITLE
fix: wait before sendPagePerformance

### DIFF
--- a/bucky.coffee
+++ b/bucky.coffee
@@ -372,9 +372,11 @@ exportDef = ->
         path = requests.urlToKey(document.location.toString()) + '.page'
 
       if document.readyState in ['uninitialized', 'loading']
-        # The data isn't fully ready until document load
-        document.addEventListener? 'DOMContentLoaded', =>
-          sendPagePerformance.call(@, path)
+        # The data isn't fully ready until window load
+        window.addEventListener? 'load', =>
+          setTimeout ->
+              sendPagePerformance.call(@, path)
+            ,500
         , false
 
         return false


### PR DESCRIPTION
Until something better, wait 500ms after `load` event before collect page timming, see #10.
