### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "bucky",
   "description": "Collect performance data from the client",
-  "version": "0.2.8",
   "main": "bucky.js",
   "homepage": "http://github.hubspot.com/bucky",
   "author": "Zack Bloom <zackbloom@gmail.com>",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property